### PR TITLE
Add parseAmount method to ParserUtil

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -14,6 +14,7 @@ import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
+import seedu.address.model.transaction.Amount;
 import seedu.address.model.transaction.MonthlyTransaction;
 import seedu.address.model.transaction.Transaction;
 import seedu.address.model.transaction.YearlyTransaction;
@@ -158,6 +159,21 @@ public class ParserUtil {
         } else {
             return new Transaction(amount, rate, description);
         }
+    }
+
+    /**
+     * Parses a {@code String amount} into an {@code Amount}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code amount} is invalid.
+     */
+    public static Amount parseAmount(String amount) throws ParseException {
+        requireNonNull(amount);
+        String trimmedAmount = amount.trim();
+        if (!Amount.isValidAmount(trimmedAmount)) {
+            throw new ParseException(Amount.MESSAGE_CONSTRAINTS);
+        }
+        return new Amount(trimmedAmount);
     }
 
     /**

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -19,6 +19,7 @@ import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
+import seedu.address.model.transaction.Amount;
 import seedu.address.model.transaction.Transaction;
 
 public class ParserUtilTest {
@@ -206,6 +207,24 @@ public class ParserUtilTest {
     @Test
     public void parseTransaction_invalidValue_throwsParseException() {
         assertThrows(ParseException.class, () -> ParserUtil.parseTransaction(INVALID_TRANSACTION));
+    }
+    @Test
+    public void parseAmount_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseAmount(null));
+    }
+
+    @Test
+    public void parseAmount_invalidAmount_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseAmount(""));
+        assertThrows(ParseException.class, () -> ParserUtil.parseAmount("0"));
+        assertThrows(ParseException.class, () -> ParserUtil.parseAmount("-5"));
+        assertThrows(ParseException.class, () -> ParserUtil.parseAmount("$5.00"));
+    }
+
+    @Test
+    public void parseAmount_validAmount_returnsAmount() throws Exception {
+        assertEquals(new Amount("12.50"), ParserUtil.parseAmount("12.50"));
+        assertEquals(new Amount("12.50"), ParserUtil.parseAmount("  12.50  ")); // trims whitespace
     }
 
     @Test


### PR DESCRIPTION
Closes #61
Adds parseAmount() to ParserUtil to wire the Amount class into the parser layer.
Changes:

Added parseAmount() method in ParserUtil.java
Added tests for parseAmount() in ParserUtilTest.java