### PR TITLE
fix(settle): reject already-settled transactions

### DIFF
--- a/src/main/java/seedu/address/logic/commands/SettleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SettleCommand.java
@@ -31,6 +31,8 @@ public class SettleCommand extends Command {
     public static final String MESSAGE_NO_TRANSACTIONS = "No transactions found for %1$s.";
     public static final String MESSAGE_INVALID_TRANSACTION_DISPLAYED_INDEX =
             "The transaction index provided is invalid";
+    public static final String MESSAGE_ALREADY_SETTLED =
+            "This transaction has already been settled.";
 
     private final Index targetIndex;
     private final Index targetTransactionIndex;
@@ -72,6 +74,9 @@ public class SettleCommand extends Command {
         }
 
         Transaction transactionToSettle = transactions.get(targetTransactionIndex.getZeroBased());
+        if (transactionToSettle.isSettled()) {
+            throw new CommandException(MESSAGE_ALREADY_SETTLED);
+        }
         transactionToSettle.settleTransaction();
 
         String transactionDetails = formatTransaction(transactionToSettle);

--- a/src/test/java/seedu/address/logic/commands/SettleCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SettleCommandTest.java
@@ -95,6 +95,20 @@ public class SettleCommandTest {
     }
 
     @Test
+    public void execute_alreadySettledTransaction_throwsCommandException() throws Exception {
+        Person personToModify = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person otherPerson = model.getFilteredPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
+
+        Transaction seedTransaction = new MonthlyTransaction(personToModify, otherPerson, 10.0, 0.0, "seed");
+        seedTransaction.settleTransaction();
+        personToModify.appendTransaction(seedTransaction);
+        otherPerson.appendTransaction(seedTransaction);
+
+        SettleCommand settleCommand = new SettleCommand(INDEX_FIRST_PERSON, Index.fromOneBased(1));
+        assertCommandFailure(settleCommand, model, SettleCommand.MESSAGE_ALREADY_SETTLED);
+    }
+
+    @Test
     public void execute_validTransactionFilteredList_success() throws CommandException {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 


### PR DESCRIPTION
Throw a CommandException when attempting to settle a transaction that is already settled.