### PR TITLE
Add simplify command to preview minimal group debt settlements (settle up feature part 1)

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -212,6 +212,22 @@ Format: `settle PERSON_INDEX t/TRANSACTION_INDEX`
 
 Example: `settle 1 t/2`
 
+### Simplifying debts among a group : `simplify`
+
+Computes a minimal settlement plan for 3 or more selected people and shows who should pay whom, without modifying any transactions yet.
+
+Format: `simplify PERSON_INDEX [MORE_PERSON_INDEXES]...`
+
+* You must provide at least 3 distinct person indexes.
+* All indexes refer to the currently displayed person list.
+* Only unsettled transactions between selected people are included in the calculation.
+* The command is preview-only: it does not mark any transaction as settled.
+* The resulting plan is shown in the UI result display.
+
+Examples:
+* `simplify 1 2 3`
+* `simplify 1 2 3 4`
+
 ### Deleting a transaction : `delete`
 
 Removes a specific transaction from a person; specifying both the person index and transaction index lets you target the exact entry.
@@ -280,4 +296,5 @@ Action | Format, Examples
 **Edit** | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`
 **Find** | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find James Jake`
 **List** | `list`
+**Simplify** | `simplify PERSON_INDEX [MORE_PERSON_INDEXES]...`<br> e.g., `simplify 1 2 3 4`
 **Help** | `help`

--- a/src/main/java/seedu/address/logic/commands/SimplifyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SimplifyCommand.java
@@ -1,0 +1,266 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+import seedu.address.model.transaction.Transaction;
+
+/**
+ * Computes a simplified settlement plan among three or more selected persons.
+ * This command is a preview only and does not mutate any transactions.
+ */
+public class SimplifyCommand extends Command {
+
+    public static final String COMMAND_WORD = "simplify";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Computes a simplified debt-settlement plan among three or more persons.\n"
+            + "Parameters: PERSON_INDEX [MORE_PERSON_INDEXES...] (all must be positive integers, count >= 3)\n"
+            + "Example: " + COMMAND_WORD + " 1 2 3 4";
+
+    public static final String MESSAGE_MINIMUM_PARTICIPANTS =
+            "At least 3 distinct person indices are required.";
+    public static final String MESSAGE_DUPLICATE_PERSON_INDEX =
+            "Duplicate person index detected: %1$d";
+
+    private static final double EPSILON = 1e-6;
+
+    private final List<Index> participantIndices;
+
+    /**
+     * Creates a {@code SimplifyCommand} for the provided participant indices.
+     */
+    public SimplifyCommand(List<Index> participantIndices) {
+        requireNonNull(participantIndices);
+        this.participantIndices = List.copyOf(participantIndices);
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        if (participantIndices.size() < 3) {
+            throw new CommandException(MESSAGE_MINIMUM_PARTICIPANTS);
+        }
+
+        List<Person> lastShownList = model.getFilteredPersonList();
+        List<Person> participants = resolveParticipants(lastShownList);
+
+        List<SettlementInstruction> instructions = computeSettlementInstructions(participants);
+        String feedback = formatPlanFeedback(participants, instructions);
+        return new CommandResult(feedback);
+    }
+
+    private List<Person> resolveParticipants(List<Person> lastShownList) throws CommandException {
+        Set<Integer> seenZeroBased = new HashSet<>();
+        List<Person> participants = new ArrayList<>();
+
+        for (Index index : participantIndices) {
+            if (index.getZeroBased() >= lastShownList.size()) {
+                throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            }
+
+            int zeroBased = index.getZeroBased();
+            if (!seenZeroBased.add(zeroBased)) {
+                throw new CommandException(String.format(MESSAGE_DUPLICATE_PERSON_INDEX, index.getOneBased()));
+            }
+
+            participants.add(lastShownList.get(zeroBased));
+        }
+
+        if (participants.size() < 3) {
+            throw new CommandException(MESSAGE_MINIMUM_PARTICIPANTS);
+        }
+
+        return participants;
+    }
+
+    private static List<SettlementInstruction> computeSettlementInstructions(List<Person> participants) {
+        Map<Person, Double> netBalances = new HashMap<>();
+        participants.forEach(person -> netBalances.put(person, 0.0));
+
+        Set<Transaction> uniqueTransactions = new HashSet<>();
+        for (Person person : participants) {
+            uniqueTransactions.addAll(person.getTransactions());
+        }
+
+        for (Transaction transaction : uniqueTransactions) {
+            if (transaction.isSettled()) {
+                continue;
+            }
+
+            Person canonicalDebtor = findCanonicalParticipant(participants, transaction.getDebtor());
+            Person canonicalCreditor = findCanonicalParticipant(participants, transaction.getCreditor());
+            if (canonicalDebtor == null || canonicalCreditor == null) {
+                continue;
+            }
+
+            double amount = transaction.getCurrAmount();
+            if (Math.abs(amount) < EPSILON) {
+                continue;
+            }
+
+            netBalances.put(canonicalDebtor, netBalances.get(canonicalDebtor) - amount);
+            netBalances.put(canonicalCreditor, netBalances.get(canonicalCreditor) + amount);
+        }
+
+        List<BalanceNode> debtors = netBalances.entrySet().stream()
+                .filter(entry -> entry.getValue() < -EPSILON)
+                .map(entry -> new BalanceNode(entry.getKey(), -entry.getValue()))
+                .sorted(Comparator.comparingDouble(BalanceNode::amount).reversed())
+                .collect(Collectors.toList());
+
+        List<BalanceNode> creditors = netBalances.entrySet().stream()
+                .filter(entry -> entry.getValue() > EPSILON)
+                .map(entry -> new BalanceNode(entry.getKey(), entry.getValue()))
+                .sorted(Comparator.comparingDouble(BalanceNode::amount).reversed())
+                .collect(Collectors.toList());
+
+        List<SettlementInstruction> instructions = new ArrayList<>();
+        int debtorPointer = 0;
+        int creditorPointer = 0;
+
+        while (debtorPointer < debtors.size() && creditorPointer < creditors.size()) {
+            BalanceNode debtor = debtors.get(debtorPointer);
+            BalanceNode creditor = creditors.get(creditorPointer);
+
+            double transfer = Math.min(debtor.amount(), creditor.amount());
+            if (transfer > EPSILON) {
+                instructions.add(new SettlementInstruction(debtor.person(), creditor.person(), transfer));
+            }
+
+            debtor.decreaseBy(transfer);
+            creditor.decreaseBy(transfer);
+
+            if (debtor.amount() <= EPSILON) {
+                debtorPointer++;
+            }
+            if (creditor.amount() <= EPSILON) {
+                creditorPointer++;
+            }
+        }
+
+        return instructions;
+    }
+
+    private static Person findCanonicalParticipant(List<Person> participants, Person candidate) {
+        for (Person participant : participants) {
+            if (participant.isSamePerson(candidate)) {
+                return participant;
+            }
+        }
+        return null;
+    }
+
+    private String formatPlanFeedback(List<Person> participants, List<SettlementInstruction> instructions) {
+        String names = participants.stream()
+                .map(person -> person.getName().fullName)
+                .collect(Collectors.joining(", "));
+
+        StringBuilder builder = new StringBuilder();
+        builder.append(String.format("Simplified settlement plan (%d persons): %s", participants.size(), names));
+
+        if (instructions.isEmpty()) {
+            builder.append(System.lineSeparator())
+                    .append("No payments needed among selected persons.");
+            return builder.toString();
+        }
+
+        for (int i = 0; i < instructions.size(); i++) {
+            SettlementInstruction instruction = instructions.get(i);
+            builder.append(System.lineSeparator())
+                    .append(String.format("%d. %s pays %s $%.2f",
+                            i + 1,
+                            instruction.payer().getName().fullName,
+                            instruction.payee().getName().fullName,
+                            instruction.amount()));
+        }
+
+        return builder.toString();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if (!(other instanceof SimplifyCommand)) {
+            return false;
+        }
+        SimplifyCommand otherCommand = (SimplifyCommand) other;
+        return participantIndices.equals(otherCommand.participantIndices);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(participantIndices);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("participantIndices", participantIndices)
+                .toString();
+    }
+
+    private static final class BalanceNode {
+        private final Person person;
+        private double amount;
+
+        private BalanceNode(Person person, double amount) {
+            this.person = person;
+            this.amount = amount;
+        }
+
+        private Person person() {
+            return person;
+        }
+
+        private double amount() {
+            return amount;
+        }
+
+        private void decreaseBy(double deduction) {
+            amount -= deduction;
+        }
+    }
+
+    private static final class SettlementInstruction {
+        private final Person payer;
+        private final Person payee;
+        private final double amount;
+
+        private SettlementInstruction(Person payer, Person payee, double amount) {
+            this.payer = payer;
+            this.payee = payee;
+            this.amount = amount;
+        }
+
+        private Person payer() {
+            return payer;
+        }
+
+        private Person payee() {
+            return payee;
+        }
+
+        private double amount() {
+            return amount;
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -19,6 +19,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.SettleCommand;
+import seedu.address.logic.commands.SimplifyCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -84,6 +85,9 @@ public class AddressBookParser {
 
         case SettleCommand.COMMAND_WORD:
             return new SettleCommandParser().parse(arguments);
+
+        case SimplifyCommand.COMMAND_WORD:
+            return new SimplifyCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/SimplifyCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SimplifyCommandParser.java
@@ -1,0 +1,52 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.SimplifyCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new {@code SimplifyCommand} object.
+ */
+public class SimplifyCommandParser implements Parser<SimplifyCommand> {
+
+    @Override
+    public SimplifyCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SimplifyCommand.MESSAGE_USAGE));
+        }
+
+        String[] tokens = trimmedArgs.split("\\s+");
+        List<Index> indices = new ArrayList<>();
+        Set<Integer> uniqueOneBasedIndices = new HashSet<>();
+
+        for (String token : tokens) {
+            Index parsedIndex;
+            try {
+                parsedIndex = ParserUtil.parseIndex(token);
+            } catch (ParseException pe) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, SimplifyCommand.MESSAGE_USAGE), pe);
+            }
+
+            if (!uniqueOneBasedIndices.add(parsedIndex.getOneBased())) {
+                throw new ParseException(
+                        String.format(SimplifyCommand.MESSAGE_DUPLICATE_PERSON_INDEX, parsedIndex.getOneBased()));
+            }
+            indices.add(parsedIndex);
+        }
+
+        if (indices.size() < 3) {
+            throw new ParseException(SimplifyCommand.MESSAGE_MINIMUM_PARTICIPANTS);
+        }
+
+        return new SimplifyCommand(indices);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/SimplifyCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SimplifyCommandTest.java
@@ -1,0 +1,115 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+import seedu.address.model.transaction.Transaction;
+
+public class SimplifyCommandTest {
+
+    private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_validParticipants_buildsSettlementPreview() throws Exception {
+        Person a = model.getFilteredPersonList().get(0);
+        Person b = model.getFilteredPersonList().get(1);
+        Person c = model.getFilteredPersonList().get(2);
+
+        Transaction t1 = new Transaction(a, b, 10.0, 0.0, "a->b");
+        Transaction t2 = new Transaction(b, c, 6.0, 0.0, "b->c");
+
+        a.appendTransaction(t1);
+        b.appendTransaction(t1);
+        b.appendTransaction(t2);
+        c.appendTransaction(t2);
+
+        SimplifyCommand command = new SimplifyCommand(List.of(
+                Index.fromOneBased(1), Index.fromOneBased(2), Index.fromOneBased(3)));
+
+        CommandResult result = command.execute(model);
+
+        assertTrue(result.getFeedbackToUser().contains("Simplified settlement plan (3 persons):"));
+        assertTrue(result.getFeedbackToUser().contains("pays"));
+        assertTrue(result.getFeedbackToUser().contains("$"));
+    }
+
+    @Test
+    public void execute_groupAlreadyNetted_showsNoPaymentsNeeded() throws Exception {
+        Person a = model.getFilteredPersonList().get(0);
+        Person b = model.getFilteredPersonList().get(1);
+        Person c = model.getFilteredPersonList().get(2);
+
+        Transaction t1 = new Transaction(a, b, 10.0, 0.0, "a->b");
+        Transaction t2 = new Transaction(b, c, 10.0, 0.0, "b->c");
+        Transaction t3 = new Transaction(c, a, 10.0, 0.0, "c->a");
+
+        a.appendTransaction(t1);
+        b.appendTransaction(t1);
+        b.appendTransaction(t2);
+        c.appendTransaction(t2);
+        c.appendTransaction(t3);
+        a.appendTransaction(t3);
+
+        SimplifyCommand command = new SimplifyCommand(List.of(
+                Index.fromOneBased(1), Index.fromOneBased(2), Index.fromOneBased(3)));
+
+        CommandResult result = command.execute(model);
+        assertTrue(result.getFeedbackToUser().contains("No payments needed among selected persons."));
+    }
+
+    @Test
+    public void execute_outOfBoundsIndex_throwsCommandException() {
+        SimplifyCommand command = new SimplifyCommand(List.of(
+                Index.fromOneBased(1),
+                Index.fromOneBased(2),
+                Index.fromOneBased(model.getFilteredPersonList().size() + 1)));
+
+        assertCommandFailure(command, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_duplicateIndices_throwsCommandException() {
+        SimplifyCommand command = new SimplifyCommand(List.of(
+                Index.fromOneBased(1),
+                Index.fromOneBased(2),
+                Index.fromOneBased(2)));
+
+        assertCommandFailure(command, model,
+                String.format(SimplifyCommand.MESSAGE_DUPLICATE_PERSON_INDEX, 2));
+    }
+
+    @Test
+    public void execute_lessThanThreeParticipants_throwsCommandException() {
+        SimplifyCommand command = new SimplifyCommand(List.of(
+                Index.fromOneBased(1),
+                Index.fromOneBased(2)));
+
+        assertCommandFailure(command, model, SimplifyCommand.MESSAGE_MINIMUM_PARTICIPANTS);
+    }
+
+    @Test
+    public void equals() {
+        SimplifyCommand first = new SimplifyCommand(List.of(
+                Index.fromOneBased(1), Index.fromOneBased(2), Index.fromOneBased(3)));
+        SimplifyCommand second = new SimplifyCommand(List.of(
+                Index.fromOneBased(1), Index.fromOneBased(2), Index.fromOneBased(3)));
+        SimplifyCommand different = new SimplifyCommand(List.of(
+                Index.fromOneBased(1), Index.fromOneBased(2), Index.fromOneBased(4)));
+
+        assertTrue(first.equals(first));
+        assertTrue(first.equals(second));
+        assertFalse(first.equals(different));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -24,6 +24,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.SettleCommand;
+import seedu.address.logic.commands.SimplifyCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
@@ -96,6 +97,16 @@ public class AddressBookParserTest {
         SettleCommand command = (SettleCommand) parser.parseCommand(
                 SettleCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased() + " t/1");
         assertEquals(new SettleCommand(INDEX_FIRST_PERSON, Index.fromOneBased(1)), command);
+    }
+
+    @Test
+    public void parseCommand_simplify() throws Exception {
+        SimplifyCommand command = (SimplifyCommand) parser.parseCommand(
+                SimplifyCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased() + " 2 3");
+        assertEquals(new SimplifyCommand(List.of(
+                INDEX_FIRST_PERSON,
+                Index.fromOneBased(2),
+                Index.fromOneBased(3))), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/SimplifyCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SimplifyCommandParserTest.java
@@ -1,0 +1,47 @@
+package seedu.address.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.SimplifyCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+public class SimplifyCommandParserTest {
+
+    private final SimplifyCommandParser parser = new SimplifyCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsSimplifyCommand() throws Exception {
+        SimplifyCommand expected = new SimplifyCommand(List.of(
+                Index.fromOneBased(1),
+                Index.fromOneBased(2),
+                Index.fromOneBased(3),
+                Index.fromOneBased(4)));
+
+        assertEquals(expected, parser.parse(" 1 2 3 4 "));
+    }
+
+    @Test
+    public void parse_lessThanThreeIndices_throwsParseException() {
+        String expectedMessage = SimplifyCommand.MESSAGE_MINIMUM_PARTICIPANTS;
+        assertThrows(ParseException.class, expectedMessage, () -> parser.parse("1 2"));
+    }
+
+    @Test
+    public void parse_duplicateIndices_throwsParseException() {
+        String expectedMessage = String.format(SimplifyCommand.MESSAGE_DUPLICATE_PERSON_INDEX, 2);
+        assertThrows(ParseException.class, expectedMessage, () -> parser.parse("1 2 2"));
+    }
+
+    @Test
+    public void parse_invalidIndex_throwsParseException() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, SimplifyCommand.MESSAGE_USAGE);
+        assertThrows(ParseException.class, expectedMessage, () -> parser.parse("1 two 3"));
+    }
+}


### PR DESCRIPTION
add new simplify command for 3+ selected persons
compute net balances from unsettled in-group transactions only
generate minimized payment plan (payer, payee, amount) without mutating data
wire simplify parsing/dispatch into command parser
add parser and command tests for validation and edge cases
update UserGuide with simplify usage and examples

Use this full scenario:

clear

add n/A p/90000001 e/a@example.com a/1
add n/B p/90000002 e/b@example.com a/2
add n/C p/90000003 e/c@example.com a/3
add n/D p/90000004 e/d@example.com a/4
add n/E p/90000005 e/e@example.com a/5


Then add transactions:

addtxn 1 4 a/40 i/0 d/A-to-D t/n
addtxn 2 4 a/10 i/0 d/B-to-D t/n
addtxn 2 5 a/20 i/0 d/B-to-E t/n
addtxn 3 5 a/20 i/0 d/C-to-E t/n
Now run:
simplify 1 2 3 4 5

Expected style of result:

A pays D $40.00
B pays D $10.00
B pays E $20.00
C pays E $20.00

closes #117 