### PR TITLE
fix(addtxn): show feedback for repeated transactions

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddTransactionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTransactionCommand.java
@@ -45,6 +45,8 @@ public class AddTransactionCommand extends Command {
             + PREFIX_COMPOUNDING_TYPE + "m";
 
     public static final String MESSAGE_SUCCESS = "New transaction added: %1$s owes %2$s — %3$s";
+    public static final String MESSAGE_SUCCESS_WITH_TRANSACTION_NUMBER =
+            "New transaction added (#%1$d): %2$s owes %3$s - %4$s";
     public static final String MESSAGE_SAME_PERSON =
             "Debtor and creditor cannot be the same person.";
     public static final String MESSAGE_INVALID_DEBTOR_INDEX =
@@ -96,8 +98,20 @@ public class AddTransactionCommand extends Command {
         debtor.appendTransaction(transaction);
         creditor.appendTransaction(transaction);
 
-        return new CommandResult(String.format(MESSAGE_SUCCESS,
-                Messages.format(debtor), Messages.format(creditor), descriptor.getDescription()));
+        long transactionNumber = countTransactionsBetween(debtor, creditor);
+        return new CommandResult(String.format(MESSAGE_SUCCESS_WITH_TRANSACTION_NUMBER,
+                transactionNumber, Messages.format(debtor), Messages.format(creditor), descriptor.getDescription()));
+    }
+
+    /**
+     * Counts the number of transactions from {@code debtor} to {@code creditor}.
+     */
+    private static long countTransactionsBetween(Person debtor, Person creditor) {
+        requireNonNull(debtor);
+        requireNonNull(creditor);
+        return debtor.getTransactions().stream()
+                .filter(t -> t.getDebtor().isSamePerson(debtor) && t.getCreditor().isSamePerson(creditor))
+                .count();
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddTransactionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddTransactionCommandTest.java
@@ -1,0 +1,41 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+import seedu.address.model.transaction.TransactionDescriptor;
+import seedu.address.model.transaction.TransactionDescriptor.CompoundingType;
+
+public class AddTransactionCommandTest {
+
+    private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_sameCommandRepeated_feedbackShowsIncrementingTransactionNumber() throws Exception {
+        Person debtor = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person creditor = model.getFilteredPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
+        TransactionDescriptor descriptor = new TransactionDescriptor(CompoundingType.NONE, 12.50, 0.0, "Dinner");
+
+        AddTransactionCommand first = new AddTransactionCommand(INDEX_FIRST_PERSON, INDEX_SECOND_PERSON, descriptor);
+        CommandResult firstResult = first.execute(model);
+        assertEquals(String.format(AddTransactionCommand.MESSAGE_SUCCESS_WITH_TRANSACTION_NUMBER,
+                1L, Messages.format(debtor), Messages.format(creditor), descriptor.getDescription()),
+                firstResult.getFeedbackToUser());
+
+        AddTransactionCommand second = new AddTransactionCommand(INDEX_FIRST_PERSON, INDEX_SECOND_PERSON, descriptor);
+        CommandResult secondResult = second.execute(model);
+        assertEquals(String.format(AddTransactionCommand.MESSAGE_SUCCESS_WITH_TRANSACTION_NUMBER,
+                2L, Messages.format(debtor), Messages.format(creditor), descriptor.getDescription()),
+                secondResult.getFeedbackToUser());
+    }
+}
+


### PR DESCRIPTION
Include an incrementing transaction number in the success message so repeating the same addtxn command still updates the result display.