### PR TITLE
Add settleup command for group transaction settlement

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -228,6 +228,22 @@ Examples:
 * `simplify 1 2 3`
 * `simplify 1 2 3 4`
 
+### Settling up a group : `settleup`
+
+Marks all unsettled in-group transactions as settled in one action for 3 or more selected people.
+
+Format: `settleup PERSON_INDEX [MORE_PERSON_INDEXES]...`
+
+* You must provide at least 3 distinct person indexes.
+* All indexes refer to the currently displayed person list.
+* Only transactions where **both** the debtor and the creditor are in the selected group are settled.
+* Transactions involving anyone outside the group are left unchanged.
+* The result display shows how many transactions were settled and the total amount.
+
+Examples:
+* `settleup 1 2 3`
+* `settleup 1 2 3 4 5`
+
 ### Deleting a transaction : `delete`
 
 Removes a specific transaction from a person; specifying both the person index and transaction index lets you target the exact entry.
@@ -297,4 +313,5 @@ Action | Format, Examples
 **Find** | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find James Jake`
 **List** | `list`
 **Simplify** | `simplify PERSON_INDEX [MORE_PERSON_INDEXES]...`<br> e.g., `simplify 1 2 3 4`
+**Settle Up** | `settleup PERSON_INDEX [MORE_PERSON_INDEXES]...`<br> e.g., `settleup 1 2 3 4`
 **Help** | `help`

--- a/src/main/java/seedu/address/logic/commands/SettleUpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SettleUpCommand.java
@@ -1,0 +1,153 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+import seedu.address.model.transaction.Transaction;
+
+/**
+ * Marks all unsettled in-group transactions as settled in one action for a selected group of persons.
+ */
+public class SettleUpCommand extends Command {
+
+    public static final String COMMAND_WORD = "settleup";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Settles all unsettled transactions among three or more selected persons.\n"
+            + "Parameters: PERSON_INDEX [MORE_PERSON_INDEXES...] (all must be positive integers, count >= 3)\n"
+            + "Example: " + COMMAND_WORD + " 1 2 3 4";
+
+    public static final String MESSAGE_MINIMUM_PARTICIPANTS =
+            "At least 3 distinct person indices are required.";
+    public static final String MESSAGE_DUPLICATE_PERSON_INDEX =
+            "Duplicate person index detected: %1$d";
+    public static final String MESSAGE_SUCCESS =
+            "Settled up group (%1$d persons): %2$s\n%3$d transaction(s) settled. Total amount: $%4$.2f";
+    public static final String MESSAGE_NOTHING_TO_SETTLE =
+            "No unsettled transactions found among the selected group.";
+
+    private final List<Index> participantIndices;
+
+    /**
+     * Creates a {@code SettleUpCommand} for the provided participant indices.
+     */
+    public SettleUpCommand(List<Index> participantIndices) {
+        requireNonNull(participantIndices);
+        this.participantIndices = List.copyOf(participantIndices);
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        if (participantIndices.size() < 3) {
+            throw new CommandException(MESSAGE_MINIMUM_PARTICIPANTS);
+        }
+
+        List<Person> lastShownList = model.getFilteredPersonList();
+        List<Person> participants = resolveParticipants(lastShownList);
+
+        Set<Transaction> uniqueTransactions = new HashSet<>();
+        for (Person person : participants) {
+            uniqueTransactions.addAll(person.getTransactions());
+        }
+
+        int settled = 0;
+        double totalAmount = 0.0;
+
+        for (Transaction transaction : uniqueTransactions) {
+            if (transaction.isSettled()) {
+                continue;
+            }
+
+            Person canonicalDebtor = findCanonicalParticipant(participants, transaction.getDebtor());
+            Person canonicalCreditor = findCanonicalParticipant(participants, transaction.getCreditor());
+            if (canonicalDebtor == null || canonicalCreditor == null) {
+                continue;
+            }
+
+            totalAmount += transaction.getCurrAmount();
+            transaction.settleTransaction();
+            settled++;
+        }
+
+        String names = participants.stream()
+                .map(person -> person.getName().fullName)
+                .collect(Collectors.joining(", "));
+
+        if (settled == 0) {
+            return new CommandResult(MESSAGE_NOTHING_TO_SETTLE);
+        }
+
+        String feedback = String.format(MESSAGE_SUCCESS, participants.size(), names, settled, totalAmount);
+        return new CommandResult(feedback);
+    }
+
+    private List<Person> resolveParticipants(List<Person> lastShownList) throws CommandException {
+        Set<Integer> seenZeroBased = new HashSet<>();
+        List<Person> participants = new ArrayList<>();
+
+        for (Index index : participantIndices) {
+            if (index.getZeroBased() >= lastShownList.size()) {
+                throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            }
+
+            int zeroBased = index.getZeroBased();
+            if (!seenZeroBased.add(zeroBased)) {
+                throw new CommandException(String.format(MESSAGE_DUPLICATE_PERSON_INDEX, index.getOneBased()));
+            }
+
+            participants.add(lastShownList.get(zeroBased));
+        }
+
+        if (participants.size() < 3) {
+            throw new CommandException(MESSAGE_MINIMUM_PARTICIPANTS);
+        }
+
+        return participants;
+    }
+
+    private static Person findCanonicalParticipant(List<Person> participants, Person candidate) {
+        for (Person participant : participants) {
+            if (participant.isSamePerson(candidate)) {
+                return participant;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if (!(other instanceof SettleUpCommand)) {
+            return false;
+        }
+        SettleUpCommand otherCommand = (SettleUpCommand) other;
+        return participantIndices.equals(otherCommand.participantIndices);
+    }
+
+    @Override
+    public int hashCode() {
+        return participantIndices.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("participantIndices", participantIndices)
+                .toString();
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -19,6 +19,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.SettleCommand;
+import seedu.address.logic.commands.SettleUpCommand;
 import seedu.address.logic.commands.SimplifyCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -88,6 +89,9 @@ public class AddressBookParser {
 
         case SimplifyCommand.COMMAND_WORD:
             return new SimplifyCommandParser().parse(arguments);
+
+        case SettleUpCommand.COMMAND_WORD:
+            return new SettleUpCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/SettleUpCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SettleUpCommandParser.java
@@ -1,0 +1,52 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.SettleUpCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new {@code SettleUpCommand} object.
+ */
+public class SettleUpCommandParser implements Parser<SettleUpCommand> {
+
+    @Override
+    public SettleUpCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SettleUpCommand.MESSAGE_USAGE));
+        }
+
+        String[] tokens = trimmedArgs.split("\\s+");
+        List<Index> indices = new ArrayList<>();
+        Set<Integer> uniqueOneBasedIndices = new HashSet<>();
+
+        for (String token : tokens) {
+            Index parsedIndex;
+            try {
+                parsedIndex = ParserUtil.parseIndex(token);
+            } catch (ParseException pe) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, SettleUpCommand.MESSAGE_USAGE), pe);
+            }
+
+            if (!uniqueOneBasedIndices.add(parsedIndex.getOneBased())) {
+                throw new ParseException(
+                        String.format(SettleUpCommand.MESSAGE_DUPLICATE_PERSON_INDEX, parsedIndex.getOneBased()));
+            }
+            indices.add(parsedIndex);
+        }
+
+        if (indices.size() < 3) {
+            throw new ParseException(SettleUpCommand.MESSAGE_MINIMUM_PARTICIPANTS);
+        }
+
+        return new SettleUpCommand(indices);
+    }
+}

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -262,6 +262,11 @@ public class MainWindow extends UiPart<Stage> {
             // even when the ListView selection has not changed.
             refreshTransactionPanelFromSelection();
 
+            // Force person list cards to re-render so balance labels reflect any
+            // in-place transaction mutations (e.g. settleup) without requiring a
+            // list-level change event.
+            personListPanel.refresh();
+
             if (commandResult.isShowHelp()) {
                 handleHelp();
             }

--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -51,6 +51,13 @@ public class PersonListPanel extends UiPart<Region> {
     }
 
     /**
+     * Forces all visible person list cells to re-render, refreshing displayed data such as balance labels.
+     */
+    public void refresh() {
+        personListView.refresh();
+    }
+
+    /**
      * Creates the ChangeListener used to notify a consumer about selection changes.
      *
      * @param listener consumer to invoke with the new selection

--- a/src/test/java/seedu/address/logic/commands/SettleUpCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SettleUpCommandTest.java
@@ -1,0 +1,133 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+import seedu.address.model.transaction.Transaction;
+
+public class SettleUpCommandTest {
+
+    private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_unsettledInGroupTransactions_settlesAll() throws Exception {
+        Person a = model.getFilteredPersonList().get(0);
+        Person b = model.getFilteredPersonList().get(1);
+        Person c = model.getFilteredPersonList().get(2);
+
+        Transaction t1 = new Transaction(a, b, 10.0, 0.0, "a->b");
+        Transaction t2 = new Transaction(b, c, 6.0, 0.0, "b->c");
+
+        a.appendTransaction(t1);
+        b.appendTransaction(t1);
+        b.appendTransaction(t2);
+        c.appendTransaction(t2);
+
+        SettleUpCommand command = new SettleUpCommand(List.of(
+                Index.fromOneBased(1), Index.fromOneBased(2), Index.fromOneBased(3)));
+
+        CommandResult result = command.execute(model);
+
+        assertTrue(t1.isSettled());
+        assertTrue(t2.isSettled());
+        assertTrue(result.getFeedbackToUser().contains("2 transaction(s) settled"));
+    }
+
+    @Test
+    public void execute_allAlreadySettled_returnsNothingToSettle() throws Exception {
+        Person a = model.getFilteredPersonList().get(0);
+        Person b = model.getFilteredPersonList().get(1);
+        Person c = model.getFilteredPersonList().get(2);
+
+        Transaction t1 = new Transaction(a, b, 10.0, 0.0, "a->b");
+        t1.settleTransaction();
+        a.appendTransaction(t1);
+        b.appendTransaction(t1);
+
+        SettleUpCommand command = new SettleUpCommand(List.of(
+                Index.fromOneBased(1), Index.fromOneBased(2), Index.fromOneBased(3)));
+
+        CommandResult result = command.execute(model);
+        assertTrue(result.getFeedbackToUser().contains(SettleUpCommand.MESSAGE_NOTHING_TO_SETTLE));
+    }
+
+    @Test
+    public void execute_outOfGroupTransactionNotSettled() throws Exception {
+        Person a = model.getFilteredPersonList().get(0);
+        Person b = model.getFilteredPersonList().get(1);
+        Person c = model.getFilteredPersonList().get(2);
+        Person d = model.getFilteredPersonList().get(3);
+
+        Transaction t1 = new Transaction(a, b, 10.0, 0.0, "a->b");
+        Transaction t2 = new Transaction(a, d, 5.0, 0.0, "a->d");
+
+        a.appendTransaction(t1);
+        b.appendTransaction(t1);
+        a.appendTransaction(t2);
+        d.appendTransaction(t2);
+
+        SettleUpCommand command = new SettleUpCommand(List.of(
+                Index.fromOneBased(1), Index.fromOneBased(2), Index.fromOneBased(3)));
+
+        command.execute(model);
+
+        assertTrue(t1.isSettled());
+        assertFalse(t2.isSettled());
+    }
+
+    @Test
+    public void execute_outOfBoundsIndex_throwsCommandException() {
+        SettleUpCommand command = new SettleUpCommand(List.of(
+                Index.fromOneBased(1),
+                Index.fromOneBased(2),
+                Index.fromOneBased(model.getFilteredPersonList().size() + 1)));
+
+        assertCommandFailure(command, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_duplicateIndices_throwsCommandException() {
+        SettleUpCommand command = new SettleUpCommand(List.of(
+                Index.fromOneBased(1),
+                Index.fromOneBased(2),
+                Index.fromOneBased(2)));
+
+        assertCommandFailure(command, model,
+                String.format(SettleUpCommand.MESSAGE_DUPLICATE_PERSON_INDEX, 2));
+    }
+
+    @Test
+    public void execute_lessThanThreeParticipants_throwsCommandException() {
+        SettleUpCommand command = new SettleUpCommand(List.of(
+                Index.fromOneBased(1),
+                Index.fromOneBased(2)));
+
+        assertCommandFailure(command, model, SettleUpCommand.MESSAGE_MINIMUM_PARTICIPANTS);
+    }
+
+    @Test
+    public void equals() {
+        SettleUpCommand first = new SettleUpCommand(List.of(
+                Index.fromOneBased(1), Index.fromOneBased(2), Index.fromOneBased(3)));
+        SettleUpCommand second = new SettleUpCommand(List.of(
+                Index.fromOneBased(1), Index.fromOneBased(2), Index.fromOneBased(3)));
+        SettleUpCommand different = new SettleUpCommand(List.of(
+                Index.fromOneBased(1), Index.fromOneBased(2), Index.fromOneBased(4)));
+
+        assertTrue(first.equals(first));
+        assertTrue(first.equals(second));
+        assertFalse(first.equals(different));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -24,6 +24,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.SettleCommand;
+import seedu.address.logic.commands.SettleUpCommand;
 import seedu.address.logic.commands.SimplifyCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
@@ -104,6 +105,16 @@ public class AddressBookParserTest {
         SimplifyCommand command = (SimplifyCommand) parser.parseCommand(
                 SimplifyCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased() + " 2 3");
         assertEquals(new SimplifyCommand(List.of(
+                INDEX_FIRST_PERSON,
+                Index.fromOneBased(2),
+                Index.fromOneBased(3))), command);
+    }
+
+    @Test
+    public void parseCommand_settleup() throws Exception {
+        SettleUpCommand command = (SettleUpCommand) parser.parseCommand(
+                SettleUpCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased() + " 2 3");
+        assertEquals(new SettleUpCommand(List.of(
                 INDEX_FIRST_PERSON,
                 Index.fromOneBased(2),
                 Index.fromOneBased(3))), command);

--- a/src/test/java/seedu/address/logic/parser/SettleUpCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SettleUpCommandParserTest.java
@@ -1,0 +1,47 @@
+package seedu.address.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.SettleUpCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+public class SettleUpCommandParserTest {
+
+    private final SettleUpCommandParser parser = new SettleUpCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsSettleUpCommand() throws Exception {
+        SettleUpCommand expected = new SettleUpCommand(List.of(
+                Index.fromOneBased(1),
+                Index.fromOneBased(2),
+                Index.fromOneBased(3),
+                Index.fromOneBased(4)));
+
+        assertEquals(expected, parser.parse(" 1 2 3 4 "));
+    }
+
+    @Test
+    public void parse_lessThanThreeIndices_throwsParseException() {
+        String expectedMessage = SettleUpCommand.MESSAGE_MINIMUM_PARTICIPANTS;
+        assertThrows(ParseException.class, expectedMessage, () -> parser.parse("1 2"));
+    }
+
+    @Test
+    public void parse_duplicateIndices_throwsParseException() {
+        String expectedMessage = String.format(SettleUpCommand.MESSAGE_DUPLICATE_PERSON_INDEX, 2);
+        assertThrows(ParseException.class, expectedMessage, () -> parser.parse("1 2 2"));
+    }
+
+    @Test
+    public void parse_invalidIndex_throwsParseException() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, SettleUpCommand.MESSAGE_USAGE);
+        assertThrows(ParseException.class, expectedMessage, () -> parser.parse("1 two 3"));
+    }
+}


### PR DESCRIPTION
This PR adds settleup, a new command to settle all unsettled transactions among a selected group (3+ people) in one action.

Included
settleup command + parser

Tests for command, parser, and parser dispatch
User Guide updates (new section + command summary row)
Only unsettled transactions where both parties are in the selected group are settled.
Out-of-group transactions are unchanged.
Returns a summary of settled count and total amount.This PR adds settleup, a new command to settle all unsettled transactions among a selected group (3+ people) in one action.

Example usage:

addtxn 1 2 a/50 i/0 d/dinner
addtxn 2 3 a/30 i/0 d/lunch
addtxn 3 1 a/10 i/0 d/snacks
addtxn 1 4 a/25 i/0 d/taxi
simplify 1 2 3
settleup 1 2 3

All transactions between persons 1, 2, and 3 should turn green.


Closes #124 