### PR TITLE
Fix EditCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -78,6 +78,18 @@ public class EditCommand extends Command {
         }
 
         Person personToEdit = lastShownList.get(index.getZeroBased());
+
+        // Validate name uniqueness BEFORE createEditedPerson mutates any transactions
+        if (editPersonDescriptor.getName().isPresent()) {
+            Name incomingName = editPersonDescriptor.getName().get();
+            boolean nameAlreadyTaken = lastShownList.stream()
+                    .filter(p -> !p.isSamePerson(personToEdit))
+                    .anyMatch(p -> p.getName().equals(incomingName));
+            if (nameAlreadyTaken) {
+                throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+            }
+        }
+
         Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
 
         if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {


### PR DESCRIPTION
Fixes #180 

Make EditCommand ensure that there is no one else in the list with that name so no duplicate names can occur.